### PR TITLE
Core/State: Remove Legacy Save/Load to Buffer functions

### DIFF
--- a/Source/Core/Core/State.cpp
+++ b/Source/Core/Core/State.cpp
@@ -204,34 +204,6 @@ static void DoState(Core::System& system, PointerWrap& p)
   AchievementManager::GetInstance().DoState(p);
 #endif  // USE_RETRO_ACHIEVEMENTS
 }
-// Legacy version for python stubs
-void LoadFromBufferLegacy(Core::System& system, std::vector<u8>& buffer, bool emit_event)
-{
-    if (NetPlay::IsNetPlayRunning())
-    {
-        OSD::AddMessage("Loading savestates is disabled in Netplay to prevent desyncs");
-        return;
-    }
-
-    if (AchievementManager::GetInstance().IsHardcoreModeActive())
-    {
-        OSD::AddMessage("Loading savestates is disabled in RetroAchievements hardcore mode");
-        return;
-    }
-
-    Core::RunOnCPUThread(
-        system,
-        [&] {
-            if (emit_event)
-                API::GetEventHub().EmitEvent(API::Events::BeforeSaveStateLoad{ false, -1 });
-            u8* ptr = buffer.data();
-            PointerWrap p(&ptr, buffer.size(), PointerWrap::Mode::Read);
-            DoState(system, p);
-            if (emit_event)
-                API::GetEventHub().EmitEvent(API::Events::SaveStateLoad{ false, -1 });
-        },
-        true);
-}
 
 void LoadFromBuffer(Core::System& system, Common::UniqueBuffer<u8>& buffer, bool emit_event)
 {
@@ -260,29 +232,6 @@ void LoadFromBuffer(Core::System& system, Common::UniqueBuffer<u8>& buffer, bool
       },
       true);
 }
-
-// Legacy version for python stubs
-void SaveToBufferLegacy(Core::System& system, std::vector<u8>& buffer, bool emit_event)
-{
-    Core::RunOnCPUThread(
-        system,
-        [&] {
-            if (emit_event)
-                API::GetEventHub().EmitEvent(API::Events::SaveStateSave{ false, -1 });
-            u8* ptr = nullptr;
-            PointerWrap p_measure(&ptr, 0, PointerWrap::Mode::Measure);
-
-            DoState(system, p_measure);
-            const size_t buffer_size = reinterpret_cast<size_t>(ptr);
-            buffer.resize(buffer_size);
-
-            ptr = buffer.data();
-            PointerWrap p(&ptr, buffer_size, PointerWrap::Mode::Write);
-            DoState(system, p);
-        },
-        true);
-}
-
 
 void SaveToBuffer(Core::System& system, Common::UniqueBuffer<u8>& buffer, bool emit_event)
 {

--- a/Source/Core/Core/State.h
+++ b/Source/Core/Core/State.h
@@ -109,9 +109,7 @@ void SaveFile(Core::System& system, const std::string& filename, bool wait, bool
 void LoadFile(Core::System& system, const std::string& filename, bool emit_event);
 
 void SaveToBuffer(Core::System& system, Common::UniqueBuffer<u8>& buffer, bool emit_event);
-void LoadFromBuffer(Core::System& system, const Common::UniqueBuffer<u8>& buffer, bool emit_event);
-void SaveToBufferLegacy(Core::System& system, std::vector<u8>& buffer, bool emit_event);
-void LoadFromBufferLegacy(Core::System& system, std::vector<u8>& buffer, bool emit_event);
+void LoadFromBuffer(Core::System& system, Common::UniqueBuffer<u8>& buffer, bool emit_event);
 
 void LoadLastSaved(Core::System& system, int i = 1);
 void SaveFirstSaved(Core::System& system);


### PR DESCRIPTION
**IS UNTESTED**

- Now we use the optimized buffers from mainstream dolphin
- Easier maintenance since we don't have to keep manually updating the legacy function.

I don't have an environment to test functionality, but it does compile successfully on linux